### PR TITLE
Update brand logo and favicon with new assets

### DIFF
--- a/client/components/BrandLogo.tsx
+++ b/client/components/BrandLogo.tsx
@@ -5,8 +5,10 @@ interface BrandLogoProps {
   alt?: string;
 }
 
-const LOGO_DARK = "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F0af777590758424cb841fc43c86dc9a9?format=webp&width=800";
-const LOGO_LIGHT = "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F371dc2f47d9148b097176fb26df84f2d?format=webp&width=800";
+const LOGO_DARK =
+  "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F0af777590758424cb841fc43c86dc9a9?format=webp&width=800";
+const LOGO_LIGHT =
+  "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F371dc2f47d9148b097176fb26df84f2d?format=webp&width=800";
 
 export default function BrandLogo({
   className = "h-10 w-auto",

--- a/client/components/BrandLogo.tsx
+++ b/client/components/BrandLogo.tsx
@@ -5,8 +5,8 @@ interface BrandLogoProps {
   alt?: string;
 }
 
-const LOGO_DARK = "/placeholder.svg";
-const LOGO_LIGHT = "/placeholder.svg";
+const LOGO_DARK = "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F371dc2f47d9148b097176fb26df84f2d?format=webp&width=800";
+const LOGO_LIGHT = "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F371dc2f47d9148b097176fb26df84f2d?format=webp&width=800";
 
 export default function BrandLogo({
   className = "h-10 w-auto",

--- a/client/components/BrandLogo.tsx
+++ b/client/components/BrandLogo.tsx
@@ -6,7 +6,7 @@ interface BrandLogoProps {
 }
 
 const LOGO_DARK =
-  "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F0af777590758424cb841fc43c86dc9a9?format=webp&width=800";
+  "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F1809671e77ec4104926014b2da4baf41?format=webp&width=800";
 const LOGO_LIGHT =
   "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F371dc2f47d9148b097176fb26df84f2d?format=webp&width=800";
 

--- a/client/components/BrandLogo.tsx
+++ b/client/components/BrandLogo.tsx
@@ -6,7 +6,7 @@ interface BrandLogoProps {
 }
 
 const LOGO_DARK =
-  "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F1809671e77ec4104926014b2da4baf41?format=webp&width=800";
+  "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F1809671e77ec4104926014b2da4baf41?format=webp&width=1600";
 const LOGO_LIGHT =
   "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F371dc2f47d9148b097176fb26df84f2d?format=webp&width=800";
 

--- a/client/components/BrandLogo.tsx
+++ b/client/components/BrandLogo.tsx
@@ -5,10 +5,8 @@ interface BrandLogoProps {
   alt?: string;
 }
 
-const LOGO_DARK =
-  "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2Fc1294c5b215140a7b230049014fe792e?format=webp&width=800";
-const LOGO_LIGHT =
-  "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2Fc1294c5b215140a7b230049014fe792e?format=webp&width=800";
+const LOGO_DARK = "/placeholder.svg";
+const LOGO_LIGHT = "/placeholder.svg";
 
 export default function BrandLogo({
   className = "h-10 w-auto",

--- a/client/components/BrandLogo.tsx
+++ b/client/components/BrandLogo.tsx
@@ -5,7 +5,7 @@ interface BrandLogoProps {
   alt?: string;
 }
 
-const LOGO_DARK = "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F371dc2f47d9148b097176fb26df84f2d?format=webp&width=800";
+const LOGO_DARK = "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F0af777590758424cb841fc43c86dc9a9?format=webp&width=800";
 const LOGO_LIGHT = "https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F371dc2f47d9148b097176fb26df84f2d?format=webp&width=800";
 
 export default function BrandLogo({

--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" href="https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F62e5e80c8f66410c979df7293c9b5ffa?format=webp&width=512" />
+    <link
+      rel="icon"
+      href="https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F62e5e80c8f66410c979df7293c9b5ffa?format=webp&width=512"
+    />
     <link
       rel="icon"
       type="image/webp"

--- a/index.html
+++ b/index.html
@@ -3,20 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" href="https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F62e5e80c8f66410c979df7293c9b5ffa?format=webp&width=512" />
     <link
       rel="icon"
       type="image/webp"
-      href="https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2Fc1294c5b215140a7b230049014fe792e?format=webp&width=512"
+      href="https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F62e5e80c8f66410c979df7293c9b5ffa?format=webp&width=512"
     />
     <link
       rel="apple-touch-icon"
-      href="https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2Fc1294c5b215140a7b230049014fe792e?format=webp&width=512"
+      href="https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F62e5e80c8f66410c979df7293c9b5ffa?format=webp&width=512"
     />
     <meta name="application-name" content="Axisphere" />
     <meta
       name="msapplication-TileImage"
-      content="https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2Fc1294c5b215140a7b230049014fe792e?format=webp&width=512"
+      content="https://cdn.builder.io/api/v1/image/assets%2F59bf3e928fc9473a97d5e87470c824bb%2F62e5e80c8f66410c979df7293c9b5ffa?format=webp&width=512"
     />
     <!-- Open Graph / Twitter -->
     <meta


### PR DESCRIPTION
## Purpose
Replace the existing Builder.io logo with a custom brand logo across the application. The user requested to update both the main logo component (with separate assets for light and dark modes) and replace the favicon with the new brand image instead of the default Builder.io favicon.

## Code changes
- **BrandLogo.tsx**: Updated `LOGO_DARK` and `LOGO_LIGHT` constants with new Builder.io CDN asset URLs for theme-specific logo variants
- **index.html**: Replaced favicon and related icon references (including apple-touch-icon and msapplication-TileImage) with new brand asset URL, maintaining proper fallback structure

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6e64935e019e4d86a8c0319ad5b0dd75/pixel-zone)

👀 [Preview Link](https://6e64935e019e4d86a8c0319ad5b0dd75-pixel-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6e64935e019e4d86a8c0319ad5b0dd75</projectId>-->
<!--<branchName>pixel-zone</branchName>-->